### PR TITLE
[build] set up Travis CI to run the unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 install:
 - make -B vendor
 
-script: make test
+script: make verify
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+
+go:
+- 1.8
+
+# blech, Travis downloads with capitals in DirectXMan12, which confuses go
+go_import_path: github.com/directxman12/k8s-prometheus-adapter
+
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:masterminds/glide'
+    packages:
+    - glide
+
+install:
+- make -B vendor
+
+script: make test
+
+cache:
+  directories:
+  - ~/.glide

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifeq ($(ARCH),s390x)
 	BASEIMAGE?=s390x/busybox
 endif
 
-.PHONY: all build docker-build push-% push test
+.PHONY: all build docker-build push-% push test verify-gofmt gofmt verify
 
 all: build
 build: vendor
@@ -56,3 +56,11 @@ vendor: glide.lock
 
 test: vendor
 	CGO_ENABLED=0 go test ./pkg/...
+
+verify-gofmt:
+	./hack/gofmt-all.sh -v
+
+gofmt:
+	./hack/gofmt-all.sh
+
+verify: verify-gofmt test

--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -17,27 +17,27 @@ limitations under the License.
 package main
 
 import (
-    "flag"
-    "os"
-    "runtime"
+	"flag"
+	"os"
+	"runtime"
 
-    "k8s.io/apimachinery/pkg/util/wait"
-    "k8s.io/apiserver/pkg/util/logs"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/util/logs"
 
 	"github.com/directxman12/k8s-prometheus-adapter/cmd/adapter/app"
 )
 
 func main() {
-    logs.InitLogs()
-    defer logs.FlushLogs()
+	logs.InitLogs()
+	defer logs.FlushLogs()
 
-    if len(os.Getenv("GOMAXPROCS")) == 0 {
-        runtime.GOMAXPROCS(runtime.NumCPU())
-    }
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
 
-    cmd := app.NewCommandStartPrometheusAdapterServer(os.Stdout, os.Stderr, wait.NeverStop)
-    cmd.Flags().AddGoFlagSet(flag.CommandLine)
-    if err := cmd.Execute(); err != nil {
-        panic(err)
-    }
+	cmd := app.NewCommandStartPrometheusAdapterServer(os.Stdout, os.Stderr, wait.NeverStop)
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/adapter/app/start.go
+++ b/cmd/adapter/app/start.go
@@ -17,23 +17,23 @@ limitations under the License.
 package app
 
 import (
-	"net/http"
-	"net/url"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/pkg/api"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/directxman12/custom-metrics-boilerplate/pkg/cmd/server"
-	cmprov "github.com/directxman12/k8s-prometheus-adapter/pkg/custom-provider"
 	prom "github.com/directxman12/k8s-prometheus-adapter/pkg/client"
 	mprom "github.com/directxman12/k8s-prometheus-adapter/pkg/client/metrics"
+	cmprov "github.com/directxman12/k8s-prometheus-adapter/pkg/custom-provider"
 )
 
 // NewCommandStartPrometheusAdapterServer provides a CLI handler for 'start master' command
@@ -41,9 +41,9 @@ func NewCommandStartPrometheusAdapterServer(out, errOut io.Writer, stopCh <-chan
 	baseOpts := server.NewCustomMetricsAdapterServerOptions(out, errOut)
 	o := PrometheusAdapterServerOptions{
 		CustomMetricsAdapterServerOptions: baseOpts,
-		MetricsRelistInterval: 10 * time.Minute,
-		RateInterval: 5 * time.Minute,
-		PrometheusURL: "https://localhost",
+		MetricsRelistInterval:             10 * time.Minute,
+		RateInterval:                      5 * time.Minute,
+		PrometheusURL:                     "https://localhost",
 	}
 
 	cmd := &cobra.Command{

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5301bfa390fea808bce92640a9c3ea2165b8484a75a394144d242d49f4a8e6e6
-updated: 2017-06-23T21:03:10.447897871-04:00
+hash: 4432fd0d13b3a79f1febb9040cad9576793e44ab1c4d6e40abc664ad0582999f
+updated: 2017-06-27T18:59:14.961201169-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -386,10 +386,12 @@ imports:
   - plugin/pkg/authenticator/token/webhook
   - plugin/pkg/authorizer/webhook
 - name: k8s.io/client-go
-  version: 450baa5d60f8d6a251c7682cb6f86e939b750b2d
+  version: b932a6d0e02c2b5afe156f4dd193a095efd8e954
+  repo: https://github.com/directxman12/client-go.git
   subpackages:
   - discovery
   - dynamic
+  - dynamic/fake
   - informers
   - informers/apps
   - informers/apps/v1beta1
@@ -488,6 +490,7 @@ imports:
   - pkg/version
   - rest
   - rest/watch
+  - testing
   - tools/auth
   - tools/cache
   - tools/clientcmd

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,8 @@ import:
   subpackages:
   - pkg/util/logs
 - package: k8s.io/client-go
+  repo: https://github.com/directxman12/client-go.git
+  version: feature/fake-dynamic-client
   subpackages:
   - kubernetes/typed/core/v1
   - rest

--- a/hack/gofmt-all.sh
+++ b/hack/gofmt-all.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+verify=0
+if [[ ${1:-} = "--verify" || ${1:-} = "-v" ]]; then
+  verify=1
+fi
+
+find_files() {
+  find . -not \( \( \
+    -wholename './_output' \
+    -o -wholename './vendor' \
+  \) -prune \) -name '*.go'
+}
+
+if [[ $verify -eq 1 ]]; then
+  diff=$(find_files | xargs gofmt -s -d 2>&1)
+  if [[ -n "${diff}" ]]; then
+    echo "gofmt -s -w $(echo "${diff}" | awk '/^diff / { print $2 }' | tr '\n' ' ')"
+    exit 1
+  fi
+else
+  find_files | xargs gofmt -s -w
+fi

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -20,14 +20,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
-	"io/ioutil"
-	"io"
 
-	"github.com/prometheus/common/model"
 	"github.com/golang/glog"
+	"github.com/prometheus/common/model"
 )
 
 // APIClient is a raw client to the Prometheus Query API.
@@ -44,7 +44,7 @@ type GenericAPIClient interface {
 
 // httpAPIClient is a GenericAPIClient implemented in terms of an underlying http.Client.
 type httpAPIClient struct {
-	client *http.Client
+	client  *http.Client
 	baseURL *url.URL
 }
 
@@ -80,7 +80,7 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 	if code/100 != 2 && code != 400 && code != 422 && code != 503 {
 		return APIResponse{}, &Error{
 			Type: ErrBadResponse,
-			Msg: fmt.Sprintf("unknown response code %d", code),
+			Msg:  fmt.Sprintf("unknown response code %d", code),
 		}
 	}
 
@@ -106,7 +106,7 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 	if res.Status == ResponseError {
 		return res, &Error{
 			Type: res.ErrorType,
-			Msg: res.Error,
+			Msg:  res.Error,
 		}
 	}
 
@@ -116,15 +116,15 @@ func (c *httpAPIClient) Do(ctx context.Context, verb, endpoint string, query url
 // NewGenericAPIClient builds a new generic Prometheus API client for the given base URL and HTTP Client.
 func NewGenericAPIClient(client *http.Client, baseURL *url.URL) GenericAPIClient {
 	return &httpAPIClient{
-		client: client,
+		client:  client,
 		baseURL: baseURL,
 	}
 }
 
 const (
-	queryURL = "/api/v1/query"
+	queryURL      = "/api/v1/query"
 	queryRangeURL = "/api/v1/query_range"
-	seriesURL = "/api/v1/series"
+	seriesURL     = "/api/v1/series"
 )
 
 // queryClient is a Client that connects to the Prometheus HTTP API.

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -99,7 +99,7 @@ func (qr *QueryResult) UnmarshalJSON(b []byte) error {
 // Series is roughly equivalent to model.Metrics, but has easy access to name
 // and the set of non-name labels.
 type Series struct {
-	Name string
+	Name   string
 	Labels model.LabelSet
 }
 

--- a/pkg/client/metrics/metrics.go
+++ b/pkg/client/metrics/metrics.go
@@ -31,8 +31,8 @@ var (
 	// overhead and HTTP overhead.
 	queryLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "cmgateway_prometheus_query_latency_seconds",
-			Help: "Prometheus client query latency in seconds.  Broken down by target prometheus endpoint and target server",
+			Name:    "cmgateway_prometheus_query_latency_seconds",
+			Help:    "Prometheus client query latency in seconds.  Broken down by target prometheus endpoint and target server",
 			Buckets: prometheus.ExponentialBuckets(0.0001, 2, 10),
 		},
 		[]string{"endpoint", "server"},
@@ -47,7 +47,7 @@ func init() {
 // capturing request latency.
 type instrumentedGenericClient struct {
 	serverName string
-	client client.GenericAPIClient
+	client     client.GenericAPIClient
 }
 
 func (c *instrumentedGenericClient) Do(ctx context.Context, verb, endpoint string, query url.Values) (client.APIResponse, error) {
@@ -73,6 +73,6 @@ func (c *instrumentedGenericClient) Do(ctx context.Context, verb, endpoint strin
 func InstrumentGenericAPIClient(client client.GenericAPIClient, serverName string) client.GenericAPIClient {
 	return &instrumentedGenericClient{
 		serverName: serverName,
-		client: client,
+		client:     client,
 	}
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -43,6 +43,7 @@ func (e *Error) Error() string {
 
 // ResponseStatus is the type of response from the API: succeeded or error.
 type ResponseStatus string
+
 const (
 	ResponseSucceeded ResponseStatus = "succeeded"
 	ResponseError                    = "error"

--- a/pkg/custom-provider/metric_namer.go
+++ b/pkg/custom-provider/metric_namer.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"github.com/directxman12/custom-metrics-boilerplate/pkg/provider"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/golang/glog"
 	prom "github.com/directxman12/k8s-prometheus-adapter/pkg/client"
+	"github.com/golang/glog"
 	pmodel "github.com/prometheus/common/model"
 )
 
@@ -36,6 +36,7 @@ import (
 
 // SeriesType represents the kind of series backing a metric.
 type SeriesType int
+
 const (
 	CounterSeries SeriesType = iota
 	SecondsCounterSeries
@@ -97,7 +98,7 @@ func (r *basicSeriesRegistry) SetSeries(newSeries []prom.Series) error {
 	}
 
 	newMetrics := make([]provider.MetricInfo, 0, len(newInfo))
-	for info, _ := range newInfo {
+	for info := range newInfo {
 		newMetrics = append(newMetrics, info)
 	}
 
@@ -248,13 +249,13 @@ func (n *metricNamer) processContainerSeries(series prom.Series, infos map[provi
 	info := provider.MetricInfo{
 		// TODO: is the plural correct?
 		GroupResource: schema.GroupResource{Resource: "pods"},
-		Namespaced: true,
-		Metric: name,
+		Namespaced:    true,
+		Metric:        name,
 	}
 
 	infos[info] = seriesInfo{
-		kind: metricKind,
-		baseSeries: prom.Series{Name: originalName},
+		kind:        metricKind,
+		baseSeries:  prom.Series{Name: originalName},
 		isContainer: true,
 	}
 }
@@ -272,8 +273,8 @@ func (n *metricNamer) processNamespacedSeries(series prom.Series, infos map[prov
 	for _, resource := range resources {
 		info := provider.MetricInfo{
 			GroupResource: resource,
-			Namespaced: true,
-			Metric: name,
+			Namespaced:    true,
+			Metric:        name,
 		}
 
 		// metrics describing namespaces aren't considered to be namespaced
@@ -282,7 +283,7 @@ func (n *metricNamer) processNamespacedSeries(series prom.Series, infos map[prov
 		}
 
 		infos[info] = seriesInfo{
-			kind: metricKind,
+			kind:       metricKind,
 			baseSeries: prom.Series{Name: series.Name},
 		}
 	}
@@ -303,12 +304,12 @@ func (n *metricNamer) processRootScopedSeries(series prom.Series, infos map[prov
 	for _, resource := range resources {
 		info := provider.MetricInfo{
 			GroupResource: resource,
-			Namespaced: false,
-			Metric: name,
+			Namespaced:    false,
+			Metric:        name,
 		}
 
 		infos[info] = seriesInfo{
-			kind: metricKind,
+			kind:       metricKind,
 			baseSeries: prom.Series{Name: series.Name},
 		}
 	}
@@ -324,7 +325,7 @@ func (n *metricNamer) processRootScopedSeries(series prom.Series, infos map[prov
 func (n *metricNamer) groupResourcesFromSeries(series prom.Series) ([]schema.GroupResource, error) {
 	// TODO: do we need to cache this, or is ResourceFor good enough?
 	var res []schema.GroupResource
-	for label, _ := range series.Labels {
+	for label := range series.Labels {
 		// TODO: figure out a way to let people specify a fully-qualified name in label-form
 		// TODO: will this work when missing a group?
 		gvr, err := n.mapper.ResourceFor(schema.GroupVersionResource{Resource: string(label)})

--- a/pkg/custom-provider/metric_namer_test.go
+++ b/pkg/custom-provider/metric_namer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"github.com/directxman12/custom-metrics-boilerplate/pkg/provider"
+	pmodel "github.com/prometheus/common/model"
 
 	// install extensions so that our RESTMapper knows about it
 	_ "k8s.io/client-go/pkg/apis/extensions/install"
@@ -53,7 +54,7 @@ func TestMetricNamerContainerSeries(t *testing.T) {
 		{
 			input: prom.Series{
 				Name: "container_actually_gauge_seconds_total",
-				Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+				Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 			},
 			outputMetricName: "actually_gauge",
 			outputInfo: seriesInfo{
@@ -65,7 +66,7 @@ func TestMetricNamerContainerSeries(t *testing.T) {
 		{
 			input: prom.Series{
 				Name: "container_some_usage",
-				Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+				Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 			},
 			outputMetricName: "some_usage",
 			outputInfo: seriesInfo{
@@ -77,7 +78,7 @@ func TestMetricNamerContainerSeries(t *testing.T) {
 		{
 			input: prom.Series{
 				Name: "container_some_count_total",
-				Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+				Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 			},
 			outputMetricName: "some_count",
 			outputInfo: seriesInfo{
@@ -89,7 +90,7 @@ func TestMetricNamerContainerSeries(t *testing.T) {
 		{
 			input: prom.Series{
 				Name: "container_some_time_seconds_total",
-				Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+				Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 			},
 			outputMetricName: "some_time",
 			outputInfo: seriesInfo{
@@ -131,63 +132,63 @@ func TestSeriesRegistry(t *testing.T) {
 		// container series
 		{
 			Name: "container_actually_gauge_seconds_total",
-			Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+			Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 		},
 		{
 			Name: "container_some_usage",
-			Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+			Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 		},
 		{
 			Name: "container_some_count_total",
-			Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+			Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 		},
 		{
 			Name: "container_some_time_seconds_total",
-			Labels: map[string]string{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+			Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
 		},
 		// namespaced series
 		// a series that should turn into multiple metrics
 		{
 			Name: "ingress_hits_total",
-			Labels: map[string]string{"ingress": "someingress", "service": "somesvc", "pod": "backend1", "namespace": "somens"},
+			Labels: pmodel.LabelSet{"ingress": "someingress", "service": "somesvc", "pod": "backend1", "namespace": "somens"},
 		},
 		{
 			Name: "ingress_hits_total",
-			Labels: map[string]string{"ingress": "someingress", "service": "somesvc", "pod": "backend2", "namespace": "somens"},
+			Labels: pmodel.LabelSet{"ingress": "someingress", "service": "somesvc", "pod": "backend2", "namespace": "somens"},
 		},
 		{
 			Name: "service_proxy_packets",
-			Labels: map[string]string{"service": "somesvc", "namespace": "somens"},
+			Labels: pmodel.LabelSet{"service": "somesvc", "namespace": "somens"},
 		},
 		{
 			Name: "work_queue_wait_seconds_total",
-			Labels: map[string]string{"deployment": "somedep", "namespace": "somens"},
+			Labels: pmodel.LabelSet{"deployment": "somedep", "namespace": "somens"},
 		},
 		// non-namespaced series
 		{
 			Name: "node_gigawatts",
-			Labels: map[string]string{"node": "somenode"},
+			Labels: pmodel.LabelSet{"node": "somenode"},
 		},
 		{
 			Name: "volume_claims_total",
-			Labels: map[string]string{"persistentvolume": "somepv"},
+			Labels: pmodel.LabelSet{"persistentvolume": "somepv"},
 		},
 		{
 			Name: "node_fan_seconds_total",
-			Labels: map[string]string{"node": "somenode"},
+			Labels: pmodel.LabelSet{"node": "somenode"},
 		},
 		// unrelated series
 		{
 			Name: "admin_coffee_liters_total",
-			Labels: map[string]string{"admin": "some-admin"},
+			Labels: pmodel.LabelSet{"admin": "some-admin"},
 		},
 		{
 			Name: "admin_unread_emails",
-			Labels: map[string]string{"admin": "some-admin"},
+			Labels: pmodel.LabelSet{"admin": "some-admin"},
 		},
 		{
 			Name: "admin_reddit_seconds_total",
-			Labels: map[string]string{"admin": "some-admin"},
+			Labels: pmodel.LabelSet{"admin": "some-admin"},
 		},
 	}
 
@@ -203,6 +204,7 @@ func TestSeriesRegistry(t *testing.T) {
 
 		expectedKind SeriesType
 		expectedQuery string
+		expectedGroupBy string
 	}{
 		// container metrics
 		{
@@ -213,6 +215,7 @@ func TestSeriesRegistry(t *testing.T) {
 
 			expectedKind: GaugeSeries,
 			expectedQuery: "container_actually_gauge_seconds_total{pod_name=\"somepod\",container_name!=\"POD\",namespace=\"somens\"}",
+			expectedGroupBy: "pod_name",
 		},
 		{
 			title: "container metrics gauge / multiple resource names",
@@ -222,6 +225,7 @@ func TestSeriesRegistry(t *testing.T) {
 
 			expectedKind: GaugeSeries,
 			expectedQuery: "container_some_usage{pod_name=~\"somepod1|somepod2\",container_name!=\"POD\",namespace=\"somens\"}",
+			expectedGroupBy: "pod_name",
 		},
 		{
 			title: "container metrics counter",
@@ -231,6 +235,7 @@ func TestSeriesRegistry(t *testing.T) {
 
 			expectedKind: CounterSeries,
 			expectedQuery: "container_some_count_total{pod_name=~\"somepod1|somepod2\",container_name!=\"POD\",namespace=\"somens\"}",
+			expectedGroupBy: "pod_name",
 		},
 		{
 			title: "container metrics seconds counter",
@@ -240,6 +245,7 @@ func TestSeriesRegistry(t *testing.T) {
 
 			expectedKind: SecondsCounterSeries,
 			expectedQuery: "container_some_time_seconds_total{pod_name=~\"somepod1|somepod2\",container_name!=\"POD\",namespace=\"somens\"}",
+			expectedGroupBy: "pod_name",
 		},
 		// namespaced metrics
 		{
@@ -315,13 +321,19 @@ func TestSeriesRegistry(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		outputKind, outputQuery, found := registry.QueryForMetric(testCase.info, testCase.namespace, testCase.resourceNames...)
+		outputKind, outputQuery, groupBy, found := registry.QueryForMetric(testCase.info, testCase.namespace, testCase.resourceNames...)
 		if !assert.True(found, "%s: metric %v should available", testCase.title, testCase.info) {
 			continue
 		}
 
 		assert.Equal(testCase.expectedKind, outputKind, "%s: metric %v should have had the right series type", testCase.title, testCase.info)
 		assert.Equal(prom.Selector(testCase.expectedQuery), outputQuery, "%s: metric %v should have produced the correct query for %v in namespace %s", testCase.title, testCase.info, testCase.resourceNames, testCase.namespace)
+
+		expectedGroupBy := testCase.expectedGroupBy
+		if expectedGroupBy == "" {
+			expectedGroupBy = testCase.info.GroupResource.Resource
+		}
+		assert.Equal(expectedGroupBy, groupBy, "%s: metric %v should have produced the correct groupBy clause", testCase.title)
 	}
 
 	allMetrics := registry.ListAllMetrics()


### PR DESCRIPTION
This commit sets up Travis CI to run the unit tests.
It installs glide, initializes the vendor directory,
and then runs `make test`.

Part of #11.