### PR TITLE
Use rm -rf instead of sudo when removing the temp dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docker-build: vendor
 		CGO_ENABLED=0 go build -a -tags netgo -o /build/adapter github.com/directxman12/k8s-prometheus-adapter/cmd/adapter"
 
 	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(VERSION) $(TEMP_DIR)
-	sudo rm -r $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
 
 push-%:
 	$(MAKE) ARCH=$* docker-build


### PR DESCRIPTION
The directory is owned by the user running make, but some files in it are owned by root since they are created by programs running within a docker container running as root. This doesn't matter, unlinking files is a write operation on the directory that contains them. Thus write access to the root-owned files isn't required.