### PR TITLE
[docs] update to v1.9 API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Kubernetes Custom Metrics Adapter for Prometheus
 
 This repository contains an implementation of the Kubernetes custom
 metrics API
-([custom-metrics.metrics.k8s.io/v1alpha1](https://github.com/kubernetes/metrics/tree/master/pkg/apis/custom_metrics)),
+([custom.metrics.k8s.io/v1beta1](https://github.com/kubernetes/metrics/tree/master/pkg/apis/custom_metrics)),
 suitable for use with the autoscaling/v2 Horizontal Pod Autoscaler in
 Kubernetes 1.6+.
 
@@ -65,7 +65,7 @@ Additionally, [@luxas](https://github.com/luxas) has an excellent example
 deployment of Prometheus, this adapter, and a demo pod which serves
 a metric `http_requests_total`, which becomes the custom metrics API
 metric `pods/http_requests`.  It also autoscales on that metric using the
-`autoscaling/v2alpha1` HorizontalPodAutoscaler.
+`autoscaling/v2beta1` HorizontalPodAutoscaler.
 
 It can be found at https://github.com/luxas/kubeadm-workshop.  Pay special
 attention to:

--- a/deploy/manifests/custom-metrics-apiserver-auth-delegator-cluster-role-binding.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-auth-delegator-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics:system:auth-delegator

--- a/deploy/manifests/custom-metrics-apiserver-auth-reader-role-binding.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-auth-reader-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: custom-metrics-auth-reader

--- a/deploy/manifests/custom-metrics-apiserver-deployment.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/manifests/custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/deploy/manifests/custom-metrics-cluster-role.yaml
+++ b/deploy/manifests/custom-metrics-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-server-resources

--- a/deploy/manifests/custom-metrics-resource-reader-cluster-role.yaml
+++ b/deploy/manifests/custom-metrics-resource-reader-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader

--- a/deploy/manifests/hpa-custom-metrics-cluster-role-binding.yaml
+++ b/deploy/manifests/hpa-custom-metrics-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: hpa-controller-custom-metrics


### PR DESCRIPTION
This updates the README and walkthrough to use v1.9 API versions,
and to use Prometheus v2.