### PR TITLE
Add missing `create` on api registration

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -344,7 +344,7 @@ spec:
 Register that registration object with the aggregator:
 
 ```shell
-$ kubectl -f cm-registration.yaml
+$ kubectl create -f cm-registration.yaml
 ```
 
 ### Double-Checking Your Work ###


### PR DESCRIPTION
when creating the custom APIService the example was missing the `create` portion of the `kubectl` command.