### PR TITLE
Explicitly mount /tmp as an emptyDir

### DIFF
--- a/deploy/manifests/custom-metrics-apiserver-deployment.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         - mountPath: /etc/adapter/
           name: config
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-vol
       volumes:
       - name: volume-serving-cert
         secret:
@@ -46,3 +48,5 @@ spec:
       - name: config
         configMap:
           name: adapter-config
+      - name: tmp-vol
+        emptyDir: {}


### PR DESCRIPTION
If using an image build with `FROM scratch` (as built by the
build-local-images make target), you need to explictly mount
/tmp as an emptyDir.

Fixes #80 