### PR TITLE
[docs] Advice on relist interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ adapter talks to Prometheus and the main Kubernetes cluster:
   in-cluster config.
 
 - `--metrics-relist-interval=<duration>`: This is the interval at which to
-  update the cache of available metrics from Prometheus.
+  update the cache of available metrics from Prometheus.  Since the adapter
+  only lists metrics during discovery that exist between the current time and
+  the last discovery query, it's necessary to set your relist interval to
+  *at least* your Prometheus scrape interval, otherwise your metrics will
+  occaisonally disappear from the adapter.
 
 - `--prometheus-url=<url>`: This is the URL used to connect to Prometheus.
   It will eventually contain query parameters to configure the connection.


### PR DESCRIPTION
This documents that the relist interval must be at least the Prometheus
scrape interval, lest metrics fade in and out.

Closes #77 