### PR TITLE
sets the right path for config file

### DIFF
--- a/deploy/manifests/custom-metrics-apiserver-deployment.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - --prometheus-url=http://prometheus.prom.svc:9090/
         - --metrics-relist-interval=1m
         - --v=10
-        - --config=/default-config.yaml
+        - --config=/etc/adapter/config.yaml
         ports:
         - containerPort: 6443
         volumeMounts:


### PR DESCRIPTION
The configmap is mounted under /etc/adapter/config.yaml instead of /default/adapter-config.yaml