### PR TITLE
Use type kubernetes.io/tls for adapter TLS certificates

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,13 +2,15 @@ Example Deployment
 ==================
 
 1. Make sure you've built the included Dockerfile with `make docker-build`. The image should be tagged as `directxman12/k8s-prometheus-adapter:latest`.
-   
+
 2. Create a secret called `cm-adapter-serving-certs` with two values:
    `serving.crt` and `serving.key`. These are the serving certificates used
    by the adapter for serving HTTPS traffic.  For more information on how to
    generate these certificates, see the [auth concepts
    documentation](https://github.com/kubernetes-incubator/apiserver-builder/blob/master/docs/concepts/auth.md)
    in the apiserver-builder repository.
+   The kube-prometheus project published two scripts [gencerts.sh](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/experimental/custom-metrics-api/gencerts.sh)
+   and [deploy.sh](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/experimental/custom-metrics-api/deploy.sh) to create the `cm-adapter-serving-certs` secret.
 
 3. `kubectl create namespace custom-metrics` to ensure that the namespace that we're installing
    the custom metrics adapter in exists.


### PR DESCRIPTION
This PR uses standard `kubernetes.io/tls` secret type for the adapter TLS certificates.

Also I documented a little bit in detail how the user can get this certificates ready.

I fixed the deployment so that it works. The config file reference was wrong. `/etc/adapter/config.yaml` works for me.