### PR TITLE
use strict unmarshalling to ensure correct configuration

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -25,7 +25,7 @@ func FromFile(filename string) (*MetricsDiscoveryConfig, error) {
 // FromYAML loads the configuration from a blob of YAML.
 func FromYAML(contents []byte) (*MetricsDiscoveryConfig, error) {
 	var cfg MetricsDiscoveryConfig
-	if err := yaml.Unmarshal(contents, &cfg); err != nil {
+	if err := yaml.UnmarshalStrict(contents, &cfg); err != nil {
 		return nil, fmt.Errorf("unable to parse metrics discovery config: %v", err)
 	}
 	return &cfg, nil


### PR DESCRIPTION
UnmarshalStrict instead of Unmarshal will cause a failure if the config a users uses does not properly unmarshal into the config struct. This is nice because it will help quickly determine if you are missing something, or have a field in the wrong place.