### PR TITLE
Support custom ca certificate to talk to Prometheus

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -76,14 +76,14 @@ func (cmd *PrometheusAdapter) makePromClient() (prom.Client, error) {
 			return nil, err
 		}
 		httpClient = prometheusCAClient
-		fmt.Println("successfully loaded ca file")
+		glog.Info("successfully loaded ca from file")
 	} else {
 		kubeconfigHTTPClient, err := makeKubeconfigHTTPClient(cmd.PrometheusAuthInCluster, cmd.PrometheusAuthConf)
 		if err != nil {
 			return nil, err
 		}
 		httpClient = kubeconfigHTTPClient
-		fmt.Println("successfully using in cluster")
+		glog.Info("successfully using in-cluster auth")
 	}
 
 	genericPromClient := prom.NewGenericAPIClient(httpClient, baseURL)

--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -200,7 +199,9 @@ func main() {
 	cmd.Name = "prometheus-metrics-adapter"
 	cmd.addFlags()
 	cmd.Flags().AddGoFlagSet(flag.CommandLine) // make sure we get the glog flags
-	cmd.Flags().Parse(os.Args)
+	if err := cmd.Flags().Parse(os.Args); err != nil {
+		glog.Fatalf("unable to parse flags: %v", err)
+	}
 
 	// make the prometheus client
 	promClient, err := cmd.makePromClient()
@@ -280,7 +281,7 @@ func makePrometheusCAClient(caFilename string) (*http.Client, error) {
 		return nil, fmt.Errorf("failed to read prometheus-ca-file: %v", err)
 	}
 	if !pool.AppendCertsFromPEM(data) {
-		log.Printf("warning: no certs found in prometheus-ca-file")
+		return nil, fmt.Errorf("no certs found in prometheus-ca-file")
 	}
 
 	return &http.Client{

--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -272,14 +272,12 @@ func makeKubeconfigHTTPClient(inClusterAuth bool, kubeConfigPath string) (*http.
 }
 
 func makePrometheusCAClient(caFilename string) (*http.Client, error) {
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read system certificates: %v", err)
-	}
 	data, err := ioutil.ReadFile(caFilename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read prometheus-ca-file: %v", err)
 	}
+
+	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(data) {
 		return nil, fmt.Errorf("no certs found in prometheus-ca-file")
 	}


### PR DESCRIPTION
We need to be able to use another certificate to talk to Prometheus than talking to Kubernetes.
Therefore this PR adds another HTTP client that gets a certificate loaded from a ca file.

/cc @DirectXMan12 @brancz @s-urbaniak