### PR TITLE
Add Mozilla CA cert store in the docker image and enable building from macos

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,6 @@
 FROM BASEIMAGE
+RUN mkdir -vp /etc/ssl
 COPY adapter /
+COPY cacert.pem /etc/ssl/ca-bundle.pem
 USER 1001:1001
 ENTRYPOINT ["/adapter"]


### PR DESCRIPTION
Hi.

The initial reason of this PR has to do with us using a valid `*.random.com` certificate for our ssl enabled prometheus server, inside AWS EKS. And getting this error `x509: failed to load system roots and no roots provided`.

While looking at the source code i found the undocumented (and not available in the official stable chart) option `--prometheus-ca-file` that we could have used to mitigate this, but i decided to open this PR anyway, maybe somebody else could use the features that it introduces.

Related issue: #119

Introduces changes:
- Enable building from macos `LOCAL_OS=macos make docker-build` by using `gsed` (`brew install gnu-sed`)
- Fix a `docker-for-mac` issue with shared directories (docker container mounts failed) not being canonicalize (because `ls -l /tmp -> private/tmp` in macos) by using `readlink` and `greadlink` (`brew install coreutils`)
- Download and verify Mozilla CA cert store in PEM format provided by `curl` [here](https://curl.haxx.se/docs/caextract.html) 
- Add the cert store to the docker image in an arbitrary chosen path from [this](https://golang.org/src/crypto/x509/root_linux.go) list