### PR TITLE
Fix namespaced bug of node resource for issue #178

### DIFF
--- a/pkg/custom-provider/metric_namer.go
+++ b/pkg/custom-provider/metric_namer.go
@@ -13,9 +13,12 @@ import (
 	"github.com/directxman12/k8s-prometheus-adapter/pkg/naming"
 )
 
-var nsGroupResource = schema.GroupResource{Resource: "namespaces"}
-var nodeGroupResource = schema.GroupResource{Resource: "nodes"}
-var groupNameSanitizer = strings.NewReplacer(".", "_", "-", "_")
+var (
+	nsGroupResource    = schema.GroupResource{Resource: "namespaces"}
+	nodeGroupResource  = schema.GroupResource{Resource: "nodes"}
+	pvGroupResource    = schema.GroupResource{Resource: "persistentvolumes"}
+	groupNameSanitizer = strings.NewReplacer(".", "_", "-", "_")
+)
 
 // MetricNamer knows how to convert Prometheus series names and label names to
 // metrics API resources, and vice-versa.  MetricNamers should be safe to access

--- a/pkg/custom-provider/metric_namer.go
+++ b/pkg/custom-provider/metric_namer.go
@@ -14,6 +14,7 @@ import (
 )
 
 var nsGroupResource = schema.GroupResource{Resource: "namespaces"}
+var nodeGroupResource = schema.GroupResource{Resource: "nodes"}
 var groupNameSanitizer = strings.NewReplacer(".", "_", "-", "_")
 
 // MetricNamer knows how to convert Prometheus series names and label names to

--- a/pkg/custom-provider/series_registry.go
+++ b/pkg/custom-provider/series_registry.go
@@ -99,7 +99,7 @@ func (r *basicSeriesRegistry) SetSeries(newSeriesSlices [][]prom.Series, namers 
 				}
 
 				// namespace metrics aren't counted as namespaced
-				if resource == nsGroupResource {
+				if resource == nsGroupResource || resource == nodeGroupResource {
 					info.Namespaced = false
 				}
 

--- a/pkg/custom-provider/series_registry.go
+++ b/pkg/custom-provider/series_registry.go
@@ -99,7 +99,7 @@ func (r *basicSeriesRegistry) SetSeries(newSeriesSlices [][]prom.Series, namers 
 				}
 
 				// namespace metrics aren't counted as namespaced
-				if resource == nsGroupResource || resource == nodeGroupResource {
+				if resource == nsGroupResource || resource == nodeGroupResource || resource == pvGroupResource {
 					info.Namespaced = false
 				}
 

--- a/pkg/naming/resource_converter.go
+++ b/pkg/naming/resource_converter.go
@@ -177,7 +177,7 @@ func (r *resourceConverter) ResourcesForSeries(series prom.Series) ([]schema.Gro
 				}
 			}
 
-			if groupRes == nsGroupResource {
+			if groupRes != nsGroupResource {
 				namespaced = true
 			}
 		}

--- a/pkg/naming/resource_converter.go
+++ b/pkg/naming/resource_converter.go
@@ -20,6 +20,8 @@ import (
 var (
 	groupNameSanitizer = strings.NewReplacer(".", "_", "-", "_")
 	nsGroupResource    = schema.GroupResource{Resource: "namespaces"}
+	nodeGroupResource  = schema.GroupResource{Resource: "nodes"}
+	pvGroupResource    = schema.GroupResource{Resource: "persistentvolumes"}
 )
 
 // ResourceConverter knows the relationship between Kubernetes group-resources and Prometheus labels,
@@ -177,7 +179,7 @@ func (r *resourceConverter) ResourcesForSeries(series prom.Series) ([]schema.Gro
 				}
 			}
 
-			if groupRes != nsGroupResource {
+			if groupRes != nsGroupResource && groupRes != nodeGroupResource && groupRes != pvGroupResource {
 				namespaced = true
 			}
 		}


### PR DESCRIPTION
Fix issue:[#178](https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/178)

Fix namespaced bug of node resource, node resource should be a
non-namespaced resource as the resource namespace.

By doing this fix, node resouce can be accessed as expected, as the issue explains.

Closes issue:[#178](https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/178)