### PR TITLE
pkg/external-provider: set metric name for scalar values

### DIFF
--- a/pkg/external-provider/provider.go
+++ b/pkg/external-provider/provider.go
@@ -59,7 +59,7 @@ func (p *externalPrometheusProvider) GetExternalMetric(namespace string, metricS
 		// don't leak implementation details to the user
 		return nil, apierr.NewInternalError(fmt.Errorf("unable to fetch metrics"))
 	}
-	return p.metricConverter.Convert(queryResults)
+	return p.metricConverter.Convert(info, queryResults)
 }
 
 func (p *externalPrometheusProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {

--- a/pkg/naming/metrics_query_test.go
+++ b/pkg/naming/metrics_query_test.go
@@ -341,17 +341,16 @@ func TestBuildExternalSelector(t *testing.T) {
 			),
 		},
 		{
-			name: "multiple LabelValuesByName",
+			name: "single LabelValuesByName with multiple selectors",
 
 			mq: mustNewQuery(`<<.LabelValuesByName>>`, false),
 			metricSelector: labels.NewSelector().Add(
-				*mustNewLabelRequirement("foo", selection.Equals, []string{"bar"}),
-				*mustNewLabelRequirement("qux", selection.In, []string{"bar", "baz"}),
+				*mustNewLabelRequirement("foo", selection.In, []string{"bar", "baz"}),
 			),
 
 			check: checks(
 				hasError(nil),
-				hasSelector("map[foo:bar qux:bar|baz]"),
+				hasSelector("map[foo:bar|baz]"),
 			),
 		},
 	}


### PR DESCRIPTION
Currently simple external scalar values don't have a value attached:
```
{
  "kind": "ExternalMetricValueList",
  "apiVersion": "external.metrics.k8s.io/v1beta1",
  "metadata": {
    "selfLink": "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/http_requests_per_second"
  },
  "items": [
    {
      "metricName": "",
..
      "value": "100133m"
    }
  ]
}
```
This fixes it:
```
{
  "kind": "ExternalMetricValueList",
  "apiVersion": "external.metrics.k8s.io/v1beta1",
  "metadata": {
    "selfLink": "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/http_requests_per_second"
  },
  "items": [
    {
      "metricName": "http_requests_per_second",
...
      "value": "100133m"
    }
  ]
}
```