### PR TITLE
*: use proper golang image and always set go111module in build pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ ARCH?=amd64
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 OUT_DIR?=./_output
-VENDOR_DOCKERIZED=0
 
 VERSION?=latest
-GOIMAGE=golang:1.10
+GOIMAGE=golang:1.12
+GO111MODULE=on
+export GO111MODULE
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=busybox


### PR DESCRIPTION
This is a follow-up to #212.

- `VENDOR_DOCKERIZED` is no longer needed
- `GOIMAGE` needs to be updated. This part is not tested in CI, so it wasn't checked in #212
- setting `GO111MODULE` in Makefile should improve developer experience.

/cc @s-urbaniak 