### PR TITLE
Yaml typo for seriesFilters example

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -85,7 +85,7 @@ For example:
 # match all cAdvisor metrics that aren't measured in seconds
 seriesQuery: '{__name__=~"^container_.*_total",container_name!="POD",namespace!="",pod_name!=""}'
 seriesFilters:
-  isNot: "^container_.*_seconds_total"
+  - isNot: "^container_.*_seconds_total"
 ```
 
 Association


### PR DESCRIPTION
Small thing, but missing `-` in order to make seriesFilters an array. Ran into issues getting the example to run until I saw this https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/docs/sample-config.yaml#L40

Just updating to reflect that structure