### PR TITLE
remove hard-coded amd64 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY?=directxman12
 IMAGE?=k8s-prometheus-adapter
 TEMP_DIR:=$(shell mktemp -d)
-ARCH?=amd64
+ARCH?=$(shell go env GOARCH)
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 OUT_DIR?=./_output


### PR DESCRIPTION
Set the default ARCH to be the ARCH of the golang environment.