### PR TITLE
Set --metrics-max-age default value equal to relist interval

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -250,8 +250,8 @@ func main() {
 		klog.Fatalf("unable to parse flags: %v", err)
 	}
 
-	// if --metrics-max-age is not set, make it equal to --metrics-relist-interval 
-	if cmd.MetricsMaxAge == 0 * time.Second {
+	// if --metrics-max-age is not set, make it equal to --metrics-relist-interval
+	if cmd.MetricsMaxAge == 0*time.Second {
 		cmd.MetricsMaxAge = cmd.MetricsRelistInterval
 	}
 

--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -242,13 +242,17 @@ func main() {
 	cmd := &PrometheusAdapter{
 		PrometheusURL:         "https://localhost",
 		MetricsRelistInterval: 10 * time.Minute,
-		MetricsMaxAge:         20 * time.Minute,
 	}
 	cmd.Name = "prometheus-metrics-adapter"
 	cmd.addFlags()
 	cmd.Flags().AddGoFlagSet(flag.CommandLine) // make sure we get the klog flags
 	if err := cmd.Flags().Parse(os.Args); err != nil {
 		klog.Fatalf("unable to parse flags: %v", err)
+	}
+
+	// if --metrics-max-age is not set, make it equal to --metrics-relist-interval 
+	if cmd.MetricsMaxAge == 0 * time.Second {
+		cmd.MetricsMaxAge = cmd.MetricsRelistInterval
 	}
 
 	// make the prometheus client


### PR DESCRIPTION
The`--metrics-max-age` flag has been introduced in #136 with a fixed default value of 20 minutes. 

The current default value leads to the situation that when metrics drop out of Prometheus, they are still reported in the discovery information of the Custom Metrics API (`/apis/custom.metrics.k8s.io/v1beta1`) for 20 minutes.

This can be quite confusing if you don't know about the `--metrics-max-age` flag and expect the behaviour that is described in the docs. Namely that the Prometheus Adapter discovers all metrics that have been updated since the last discovery query (defined by the relist interval), which is also the reason the relist interval must be at least as large as the Prometheus scraping interval (see #229).

By setting the default value of `--metrics-max-age` equal to the relist interval, the expected behaviour as described in the docs is preserved, but you can still set `--metrics-max-age` to some other value if you know about it.

The other way to go would be to update the docs and expect all users to set the `--metrics-max-age` flag (and the [Helm chart](https://github.com/helm/charts/blob/master/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml) would need to be updated to use it too). But this would make the configuration of the Prometheus Adapter even more complicated than it already is. It is probably easier to just remember to set the relist interval at least as large as the Prometheus scraping interval, than to additionally have to figure out what the `metrics-max-age` is and what to set it to.