### PR TITLE
Support Cross Namespace External Metrics

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,9 @@ type DiscoveryRule struct {
 	// `.GroupBy` is the comma-separated expected group-by label names. The delimeters
 	// are `<<` and `>>`.
 	MetricsQuery string `yaml:"metricsQuery,omitempty"`
+	// Options specifies additional parameters that are taken into account
+	// when configuring a rule. These can be used to fine-tune the retrieval of metrics
+	Options Options `yaml:"options,omitempty"`
 }
 
 // RegexFilter is a filter that matches positively or negatively against a regex.
@@ -78,6 +81,13 @@ type NameMapping struct {
 	// to $0 if no capture groups are present in Matches, or $1
 	// if only one is present, and will error if multiple are.
 	As string `yaml:"as"`
+}
+
+// Option describes a set of customisations for retrieving metrics
+type Options struct {
+	// option to allow cross-namespace metrics. Used to determine whether to
+	// append the namespace as a label selector when retrieving metrics
+	DetatchFromNamespace bool `yaml:"detachFromNamespace,omitempty"`
 }
 
 // ResourceRules describe the rules for querying resource metrics

--- a/pkg/naming/metric_namer.go
+++ b/pkg/naming/metric_namer.go
@@ -104,6 +104,8 @@ type metricNamer struct {
 	seriesMatchers []*ReMatcher
 
 	ResourceConverter
+
+	options config.Options
 }
 
 // queryTemplateArgs are the arguments for the metrics query template.
@@ -133,7 +135,7 @@ func (n *metricNamer) QueryForSeries(series string, resource schema.GroupResourc
 func (n *metricNamer) QueryForExternalSeries(series string, namespace string, metricSelector labels.Selector) (prom.Selector, error) {
 	//test := prom.Selector()
 	//return test, nil
-	return n.metricsQuery.BuildExternal(series, namespace, "", []string{}, metricSelector)
+	return n.metricsQuery.BuildExternal(series, namespace, "", []string{}, metricSelector, n.options)
 }
 
 func (n *metricNamer) MetricNameForSeries(series prom.Series) (string, error) {
@@ -208,6 +210,7 @@ func NamersFromConfig(cfg []config.DiscoveryRule, mapper apimeta.RESTMapper) ([]
 			nameAs:            nameAs,
 			seriesMatchers:    seriesMatchers,
 			ResourceConverter: resConv,
+			options:           rule.Options,
 		}
 
 		namers[i] = namer

--- a/pkg/naming/metrics_query_test.go
+++ b/pkg/naming/metrics_query_test.go
@@ -373,6 +373,21 @@ func TestBuildExternalSelector(t *testing.T) {
 			),
 		},
 		{
+			name: "single LabelMatchers value with namespace alt - explicit attached namespace",
+
+			mq:        mustNewQuery(`<<.LabelMatchers>>`),
+			namespace: "staging",
+			options:   config.Options{DetatchFromNamespace: false},
+			metricSelector: labels.NewSelector().Add(
+				*mustNewLabelRequirement("foo", selection.Equals, []string{"bar"}),
+			),
+
+			check: checks(
+				hasError(nil),
+				hasSelector(`foo="bar",namespaces="staging"`),
+			),
+		},
+		{
 			name: "multiple LabelMatchers value",
 
 			mq: mustNewQuery(`<<.LabelMatchers>>`),


### PR DESCRIPTION
**Context**: 
When retrieving metrics from namespace B and intending to scale with HPA Object in namespace A, the metrics will have a namespace label selector appended with Namespace A. This breaks the ability to scale based on metrics in a different namespace.

This PR adds support for this by adding an `options` field for a `DiscoveryRule`, allowing an operator to opt-in to this functionality, defaulting to the existing behaviour. 

This PR also adds logic to avoid any 64-bit Integer overflow issues when metrics retrieved from Prometheus are of the form `+Inf`. When there is an overflow, the value would return `math.MinInt64`, which is negative. Observations are that when scaling needs to happen (Prometheus returns with an `+Inf` metric value) scaling would not occur as the metrics value was a negative Integer. 

To provide a more deterministic outcome for when a metric value of `-Inf` is retrieved from Prometheus, the value `math.MinInt64` will be used, rather than relying on an overflow.

**Validations**: 
Unit tests have been added to assert that setting the `DetatchFromNamespace` in the options object results in the correct functionality. This has also been through reasonable acceptance testing by myself.
I have not been able to replicate a scenario where Prometheus returns with an `-Inf` metric value, but have been able to replicate the `+Inf` metric value scenario successfully.

**Links**: 
+ The following link is a point of reference to the issue that this PR solves: https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/195