### PR TITLE
Small typo in config example snippet

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -119,7 +119,7 @@ group-resource. For instance:
 
 ```yaml
 # the microservice label corresponds to the apps.deployment resource
-resource:
+resources:
   overrides:
     microservice: {group: "apps", resource: "deployment"}
 ```


### PR DESCRIPTION
This was a small gotcha for me as I was setting up my configuration. 