### PR TITLE
Fix NaN not to be cast to int64

### DIFF
--- a/pkg/custom-provider/provider.go
+++ b/pkg/custom-provider/provider.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
@@ -83,6 +84,12 @@ func (p *prometheusProvider) metricFor(value pmodel.SampleValue, name types.Name
 		return nil, err
 	}
 
+	var q *resource.Quantity
+	if math.IsNaN(float64(value)) {
+		q = resource.NewQuantity(0, resource.DecimalSI)
+	} else {
+		q = resource.NewMilliQuantity(int64(value*1000.0), resource.DecimalSI)
+	}
 	return &custom_metrics.MetricValue{
 		DescribedObject: ref,
 		Metric: custom_metrics.MetricIdentifier{
@@ -90,7 +97,7 @@ func (p *prometheusProvider) metricFor(value pmodel.SampleValue, name types.Name
 		},
 		// TODO(directxman12): use the right timestamp
 		Timestamp: metav1.Time{time.Now()},
-		Value:     *resource.NewMilliQuantity(int64(value*1000.0), resource.DecimalSI),
+		Value:     *q,
 	}, nil
 }
 


### PR DESCRIPTION
ref: https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/280

This pull-request prevents the NaN from being cast to int64. This is because the value of histogram_quantile(), which returns a NaN when the request is 0, such as calculating a custom metric for 95%tile, will overflow and returned `-9223372036854775808m`.