### PR TITLE
Make NodeMetrics and PodMetrics APIs match K8s conventions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
 	k8s.io/metrics v0.19.3
 	k8s.io/sample-apiserver v0.18.5
-	sigs.k8s.io/metrics-server v0.3.7-0.20201028092756-2a1d1385123b
+	sigs.k8s.io/metrics-server v0.4.1-0.20201126131427-ebfc64a74ae4
 )
 
 // forced by the inclusion of sigs.k8s.io/metrics-server's use of this in their go.mod

--- a/go.sum
+++ b/go.sum
@@ -725,8 +725,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7 h1:uuHDyjllyzRyCI
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9 h1:rusRLrDhjBp6aYtl9sGEvQJr6faoHoDLd0YcUBTZguI=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
-sigs.k8s.io/metrics-server v0.3.7-0.20201028092756-2a1d1385123b h1:k12QeCO75SLSkSwHNlZuj42D69i851Lx2qjGEtubB2M=
-sigs.k8s.io/metrics-server v0.3.7-0.20201028092756-2a1d1385123b/go.mod h1:799PonU8Bq6Yj4ZXBhZxRt86C8Zv9tvrNypHVrduK/I=
+sigs.k8s.io/metrics-server v0.4.1-0.20201126131427-ebfc64a74ae4 h1:7xwQXqnQnBCVgx0ywo/1g0A3HWsHNMDU7unQv9v8oX4=
+sigs.k8s.io/metrics-server v0.4.1-0.20201126131427-ebfc64a74ae4/go.mod h1:799PonU8Bq6Yj4ZXBhZxRt86C8Zv9tvrNypHVrduK/I=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -808,7 +808,7 @@ k8s.io/utils/trace
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/metrics-server v0.3.7-0.20201028092756-2a1d1385123b
+# sigs.k8s.io/metrics-server v0.4.1-0.20201126131427-ebfc64a74ae4
 sigs.k8s.io/metrics-server/pkg/api
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 sigs.k8s.io/structured-merge-diff/v4/fieldpath


### PR DESCRIPTION
Include the following fix to the NodeMetrics and PodMetrics APIs to match k8s
conventions: https://github.com/kubernetes-sigs/metrics-server/pull/654
- NodeMetrics and PodMetrics now have labels as they can be filtered by
them
- Field selector is now applied to NodeMetrics and PodMetrics instead
of Nodes and Pods

cc @s-urbaniak 
